### PR TITLE
smarter pickles for Triangulation, VeeringTriangulation and VeeringTriangulationLinearFamily

### DIFF
--- a/veerer/linear_family.py
+++ b/veerer/linear_family.py
@@ -238,7 +238,7 @@ class VeeringTriangulationLinearFamily(VeeringTriangulation):
             entries = []
             for x in self._subspace.list():
                 v = x.vector()
-                d = v.vector().denominator()
+                d = v.denominator()
                 entries.extend(int(x) for x in (v * d))
                 entries.append(int(d))
         else:
@@ -247,11 +247,21 @@ class VeeringTriangulationLinearFamily(VeeringTriangulation):
 
     def __setstate__(self, arg):
         r"""
-        TESTS::
+        TESTS:
+
+        An example over ZZ::
 
             sage: from veerer import VeeringTriangulation
             sage: vt = VeeringTriangulation("(0,1,2)(~0,~1,~2)", "RRB")
             sage: lf = vt.as_linear_family()
+            sage: lf2 = loads(dumps(lf))  # indirect doctest
+            sage: assert lf == lf2
+            sage: lf2._check()
+
+        An example over number fields::
+
+            sage: from veerer.linear_family import VeeringTriangulationLinearFamilies
+            sage: lf = VeeringTriangulationLinearFamilies.triangle_3_4_13_unfolding_orbit_closure()
             sage: lf2 = loads(dumps(lf))  # indirect doctest
             sage: assert lf == lf2
             sage: lf2._check()

--- a/veerer/linear_family.py
+++ b/veerer/linear_family.py
@@ -36,17 +36,24 @@ from .veering_triangulation import VeeringTriangulation
 
 if sage is not None:
     from sage.structure.element import get_coercion_model
+    from sage.rings.integer_ring import ZZ
+    from sage.rings.rational_field import QQ
     from sage.matrix.constructor import matrix
     from sage.geometry.polyhedron.constructor import Polyhedron
     from sage.arith.misc import gcd
+    from sage.categories.number_fields import NumberFields
 
     cm = get_coercion_model()
+    _NumberFields = NumberFields()
 else:
     matrix = None
     Polyhedron = None
     gcd = None
+    ZZ = None
+    QQ = None
 
     cm = None
+    _NumberFields = None
 
 
 def subspace_are_equal(subspace1, subspace2, check=True):
@@ -212,6 +219,69 @@ class VeeringTriangulationLinearFamily(VeeringTriangulation):
 
         if check:
             self._check(ValueError)
+
+    def __getstate__(self):
+        R = self.base_ring()
+        a = list(self._fp[:])
+        a.extend(self._ep)
+        a.extend(self._colouring)
+        a.append(self._mutable)
+        # NOTE: here we know that all entries have the same parent
+        if R is ZZ:
+            entries = list(map(int, self._subspace.list()))
+        elif R is QQ:
+            entries = []
+            for x in self._subspace.list():
+                entries.append(int(x.numerator()))
+                entries.append(int(x.denominator()))
+        elif _NumberFields is not None and R in _NumberFields:
+            entries = []
+            for x in self._subspace.list():
+                v = x.vector()
+                d = v.vector().denominator()
+                entries.extend(int(x) for x in (v * d))
+                entries.append(int(d))
+        else:
+            entries = self._subspace.list()
+        return a, R, entries
+
+    def __setstate__(self, arg):
+        r"""
+        TESTS::
+
+            sage: from veerer import VeeringTriangulation
+            sage: vt = VeeringTriangulation("(0,1,2)(~0,~1,~2)", "RRB")
+            sage: lf = vt.as_linear_family()
+            sage: lf2 = loads(dumps(lf))  # indirect doctest
+            sage: assert lf == lf2
+            sage: lf2._check()
+        """
+        a, R, raw_entries = arg
+        n = (len(a) - 1) // 3
+        self._n = n
+        self._fp = array('i', a[:n])
+        self._ep = array('i', a[n:2*n])
+        self._colouring = array('i', a[2*n:3*n])
+        self._mutable = a[-1]
+        self._vp = array('i', [-1] * n)
+        for i in range(n):
+            self._vp[self._fp[self._ep[i]]] = i
+
+        if R is ZZ:
+            entries = [ZZ(x) for x in raw_entries]
+        elif R is QQ:
+            entries = []
+            for i in range(0, len(raw_entries), 2):
+                entries.append(QQ((raw_entries[i], raw_entries[i + 1])))
+        elif _NumberFields is not None and R in _NumberFields:
+            entries = []
+            d = R.degree()
+            for i in range(0, len(raw_entries), d + 1):
+                v = tuple(x / raw_entries[i + d] for x in raw_entries[i:i + d])
+                entries.append(R(v))
+        self._subspace = matrix(R, len(entries) // self.num_edges(), self.num_edges(), entries)
+        if not self._mutable:
+            self._subspace.set_immutable()
 
     def veering_triangulation(self, mutable=False):
         r"""

--- a/veerer/linear_family.py
+++ b/veerer/linear_family.py
@@ -289,6 +289,8 @@ class VeeringTriangulationLinearFamily(VeeringTriangulation):
             for i in range(0, len(raw_entries), d + 1):
                 v = tuple(x / raw_entries[i + d] for x in raw_entries[i:i + d])
                 entries.append(R(v))
+        else:
+            entries = raw_entries
         self._subspace = matrix(R, len(entries) // self.num_edges(), self.num_edges(), entries)
         if not self._mutable:
             self._subspace.set_immutable()

--- a/veerer/triangulation.py
+++ b/veerer/triangulation.py
@@ -250,6 +250,46 @@ class Triangulation(object):
         if check:
             self._check(ValueError)
 
+    def __getstate__(self):
+        r"""
+        TESTS::
+
+            sage: from veerer import Triangulation
+            sage: t = Triangulation("(0,1,2)")
+            sage: dumps(t)  # indirect doctest
+            b'x\x9ck`J.KM-J-\xd2+)\xcaL\xccK/\xcdI,\xc9\xcc\xcf\xe3\nA\xe1\x152h6\x162\xc6\x162ix3z3y3\x00!\x90\xeeLM\xd2\x03\x00\xe7\x1e\x14^'
+        """
+        a = list(self._fp)
+        a.extend(self._ep)
+        a.append(self._mutable)
+        return a
+
+    def __setstate__(self, arg):
+        r"""
+            sage: from veerer import Triangulation
+            sage: t0 = Triangulation("(0,1,2)", mutable=False)
+            sage: t1 = Triangulation("(0,1,2)", mutable=True)
+            sage: s0 = loads(dumps(t0))  # indirect doctest
+            sage: assert s0 == t0
+            sage: s0._mutable
+            False
+            sage: s0._check()
+
+            sage: s1 = loads(dumps(t1))  # indirect doctest
+            sage: assert s1 == t1
+            sage: s1._mutable
+            True
+            sage: s1._check()
+        """
+        n = (len(arg) - 1) // 2
+        self._n = n
+        self._fp = array('i', arg[:n])
+        self._ep = array('i', arg[n:2*n])
+        self._mutable = arg[-1]
+        self._vp = array('i', [-1] * n)
+        for i in range(n):
+            self._vp[self._fp[self._ep[i]]] = i
+
     def set_immutable(self):
         self._mutable = False
 

--- a/veerer/veering_triangulation.py
+++ b/veerer/veering_triangulation.py
@@ -161,6 +161,50 @@ class VeeringTriangulation(Triangulation):
             if i == len(v):
                 raise error('monochromatic vertex {} of colour {}'.format(v, colour_to_string(cols[v[0]])))
 
+    def __getstate__(self):
+        r"""
+        TESTS::
+
+            sage: from veerer import VeeringTriangulation
+            sage: t = VeeringTriangulation("(0,1,2)", "BBR")
+            sage: dumps(t)  # indirect doctest
+            b'x\x9ck`J.KM-J-\xd2\x03Q\x99y\xe9\xf1%E\x99\x89y\xe9\xa59\x89%\x99\xf9y\\a\x10\xd1\x10\x14\xc1B\x06\xcd\xc6B\xc6\xd8B&\roFo&o\x06 \x04\xd1 \xc8\xd8\x99\x9a\xa4\x07\x005\xe2\x1bc'
+        """
+        a = list(self._fp)
+        a.extend(self._ep)
+        a.extend(self._colouring)
+        a.append(self._mutable)
+        return a
+
+    def __setstate__(self, arg):
+        r"""
+        TESTS::
+
+            sage: from veerer import VeeringTriangulation
+            sage: t0 = VeeringTriangulation("(0,1,2)", "BBR", mutable=False)
+            sage: t1 = VeeringTriangulation("(0,1,2)", "BBR", mutable=True)
+            sage: s0 = loads(dumps(t0))  # indirect doctest
+            sage: assert s0 == t0
+            sage: s0._mutable
+            False
+            sage: s0._check()
+
+            sage: s1 = loads(dumps(t1))  # indirect doctest
+            sage: assert s1 == t1
+            sage: s1._mutable
+            True
+            sage: s1._check()
+        """
+        n = (len(arg) - 1) // 3
+        self._n = n
+        self._fp = array('i', arg[:n])
+        self._ep = array('i', arg[n:2*n])
+        self._colouring = array('i', arg[2*n:3*n])
+        self._mutable = arg[-1]
+        self._vp = array('i', [-1] * n)
+        for i in range(n):
+            self._vp[self._fp[self._ep[i]]] = i
+
     def base_ring(self):
         from sage.rings.integer_ring import ZZ
         return ZZ


### PR DESCRIPTION
Before
```
sage: from veerer import *
sage: print(len(dumps(Triangulation("(0,1,2)"))))
160
sage: print(len(dumps(VeeringTriangulation("(0,1,2)", "RBB"))))
184
sage: print(len(dumps(VeeringTriangulationLinearFamily("(0,1,2)", "RBB", [(1, 1, 0)]))))
649
```
after
```
sage: from veerer import *
sage: print(len(dumps(Triangulation("(0,1,2)"))))
58
sage: print(len(dumps(VeeringTriangulation("(0,1,2)", "RBB"))))
69
sage: print(len(dumps(VeeringTriangulationLinearFamily("(0,1,2)", "RBB", [(1, 1, 0)]))))
127
```

Fixes #18 