### PR TITLE
Cylinder diagrams for linear subvariety

### DIFF
--- a/veerer/linear_family.py
+++ b/veerer/linear_family.py
@@ -32,6 +32,7 @@ from sage.structure.element import get_coercion_model, Matrix
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 from sage.matrix.constructor import matrix
+from sage.modules.free_module import FreeModule
 from sage.geometry.polyhedron.constructor import Polyhedron
 from sage.arith.misc import gcd
 from sage.categories.number_fields import NumberFields
@@ -658,6 +659,52 @@ class VeeringTriangulationLinearFamily(VeeringTriangulation):
     def flip_back(self, e, col, check=True):
         VeeringTriangulation.flip_back(self, e, col, Gx=self._subspace, check=check)
         self._subspace.echelonize()
+
+    def is_cylindrical(self, col=None):
+        r"""
+        Return whether this linear family consists of a union of cylinders
+        whose moduli are allowed to degenerate to infinity.
+
+        EXAMPLES::
+
+            sage: from veerer import RED, VeeringTriangulation, VeeringTriangulationLinearFamily
+            sage: faces = "(0,~2,1)(2,6,~3)(3,5,4)"
+            sage: cols = "RBRRBRB"
+            sage: K = QuadraticField(5, 'sqrt5')
+            sage: sqrt5 = K.gen()
+            sage: x = (1, 0, 1, 1/2*sqrt5 + 1/2, -1, 1/2*sqrt5 - 1/2, -1/2*sqrt5 + 1/2)
+            sage: y = (0, 1, 1, 0, 1/2*sqrt5 - 1/2, 1/2*sqrt5 - 1/2, 1)
+            sage: f = VeeringTriangulationLinearFamily(faces, cols, [x, y])
+            sage: f.is_cylindrical(RED)
+            False
+            sage: VeeringTriangulation.is_cylindrical(f, RED)
+            True
+        """
+        if col is None:
+            return self.is_cylindrical(BLUE) or self.is_cylindrical(RED)
+        if col != RED and col != BLUE:
+            raise ValueError("'col' must be one of RED or BLUE")
+        if not VeeringTriangulation.is_cylindrical(self, col):
+            return False
+        cylinders = list(self.cylinders(col))
+
+        C = []  # middle edges
+        for cyl in cylinders:
+            c = [0] * self.num_edges()  # indicatrix of the middle edges
+            for e in cyl[0]:
+                c[self._norm(e)] = 1
+            C.append(c)
+
+        # take intersection of the cylinder twists in the tangent space
+        F = FreeModule(self.base_ring(), self.num_edges())
+        H = F.submodule(self._subspace).intersection(F.submodule(C))
+
+        mid_edges = set(i for c in C for i, j in enumerate(c) if j)
+        for b in H.basis_matrix():
+            for i, j in enumerate(b):
+                if j:
+                    mid_edges.discard(i)
+        return not mid_edges
 
     def geometric_polytope(self, x_low_bound=0, y_low_bound=0, hw_bound=0, backend=None):
         r"""

--- a/veerer/linear_family.py
+++ b/veerer/linear_family.py
@@ -769,15 +769,15 @@ class VeeringTriangulationLinearFamilies:
             sage: list(VeeringTriangulationLinearFamilies.H2_prototype_parameters(5))
             [(0, 1, 1, -1)]
             sage: list(VeeringTriangulationLinearFamilies.H2_prototype_parameters(8))
-            [(0, 2, 1, 0), (0, 2, 1, 0), (0, 1, 1, -2)]
+            [(0, 2, 1, 0), (0, 1, 1, -2)]
             sage: list(VeeringTriangulationLinearFamilies.H2_prototype_parameters(9))
             [(0, 2, 1, -1)]
             sage: list(VeeringTriangulationLinearFamilies.H2_prototype_parameters(12))
-            [(0, 3, 1, 0), (0, 3, 1, 0), (0, 1, 2, -2), (0, 2, 1, -2)]
+            [(0, 3, 1, 0), (0, 1, 2, -2), (0, 2, 1, -2)]
             sage: list(VeeringTriangulationLinearFamilies.H2_prototype_parameters(13))
             [(0, 3, 1, 1), (0, 3, 1, -1), (0, 1, 1, -3)]
             sage: list(VeeringTriangulationLinearFamilies.H2_prototype_parameters(16))
-            [(0, 4, 1, 0), (0, 4, 1, 0), (0, 3, 1, -2)]
+            [(0, 4, 1, 0),  (0, 3, 1, -2)]
 
             sage: list(VeeringTriangulationLinearFamilies.H2_prototype_parameters(17, spin=0))
             [(1, 2, 2, -1), (0, 4, 1, 1), (0, 2, 1, -3)]
@@ -814,7 +814,11 @@ class VeeringTriangulationLinearFamilies:
             for b in bc.divisors():
                 c = bc // b
                 # need c + e < b
-                for s in (1,-1):
+                if e == 0:
+                    signs = (1,)
+                else:
+                    signs = (1, -1)
+                for s in signs:
                     if c + s*e < b:
                         for a in range(gcd(b, c)):
                             if gcd([a, b, c, e]) == 1:

--- a/veerer/polyhedron/linear_expression.py
+++ b/veerer/polyhedron/linear_expression.py
@@ -551,6 +551,8 @@ class ConstraintSystem:
         if backend is None:
             from .cone import default_backend
             backend = default_backend(self.base_ring())
+        elif not isinstance(backend, str):
+            raise TypeError("'backend' must be a string")
 
         if backend == 'ppl':
             from .cone import Cone_ppl

--- a/veerer/veering_triangulation.py
+++ b/veerer/veering_triangulation.py
@@ -738,41 +738,6 @@ class VeeringTriangulation(Triangulation):
         c = (self._ep > other._ep) - (self._ep < other._ep)
         return rich_to_bool(op, c)
 
-    def to_core(self, slope=VERTICAL):
-        r"""
-        Change the colour of each forward (reps. backward) flippable edge in
-        PURPLE if ``slope`` is ``VERTICAL`` (resp ``HORIZONTAL``)
-
-        EXAMPLES::
-
-            sage: from veerer import *
-
-            sage: V = VeeringTriangulation("(0,1,2)", 'RRB')
-            sage: V.to_core()
-            sage: V
-            VeeringTriangulation("(0,1,2)", "RPB")
-            sage: V.forward_flippable_edges()
-            [1]
-        """
-        if slope == VERTICAL:
-            COLOR = PURPLE
-        elif slope == HORIZONTAL:
-            COLOR = GREEN
-        else:
-            raise ValueError("slope should either be HORIZONTAL or VERTICAL")
-
-        n = self.num_edges()
-        ep = self._ep
-        for e in range(n):
-            if ep[e] < e:
-                raise ValueError("veering triangulation not in canonical form")
-            if slope == VERTICAL:
-                if self.is_forward_flippable(e, check=False):
-                    self._colouring[e] = self._colouring[ep[e]] = COLOR
-            else:
-                if self.is_backward_flippable(e, check=False):
-                    self._colouring[e] = self._colouring[ep[e]] = COLOR
-
     def copy(self, mutable=None):
         r"""
         Return a copy of this coloured triangulation.

--- a/veerer/veering_triangulation.py
+++ b/veerer/veering_triangulation.py
@@ -2342,6 +2342,7 @@ class VeeringTriangulation(Triangulation):
                 continue
             b = fp[a]
             c = fp[b]
+            seen[a] = seen[b] = seen[c] = True
             if col == PURPLE:
                 if cols[a] != PURPLE and cols[b] != PURPLE and cols[c] != PURPLE:
                     return False


### PR DESCRIPTION
We implement a function to extract cylinder diagrams for a linear subvariety. Note that `VeeringTriangulation.is_cylindrical` is not suited for `LinearFamily`. Namely the underlying veering triangulation might be cylindrical but the equations of the linear subspace might forbid the cylinders to exist. We implement a custom version for `LinearFamily` that takes care of the linear constraints.

We check in doctests that it provides the correct answer for Teichmüller curves in H(2).

Fixes #47 